### PR TITLE
DFK-289

### DIFF
--- a/frontend/src/common/util/api/util.ts
+++ b/frontend/src/common/util/api/util.ts
@@ -22,21 +22,17 @@ export const getHeader = (
 
 export type AsyncFunc<T = any> = (...args: any[]) => Promise<T>;
 
-export const withLoadingAndErrorHandling =
+export const withErrorHandling =
   (
     asyncFunc: AsyncFunc,
     errorMessage: string,
-    setLoading: (l: boolean) => void,
     setError: (e: Error | undefined) => void
   ) =>
   async (...args: any[]) => {
-    setLoading(true);
     setError(undefined);
     try {
       return await asyncFunc(...args);
     } catch (e: any) {
       setError(toError(e, errorMessage));
-    } finally {
-      setLoading(false);
     }
   };

--- a/frontend/src/maaling/overview/MaalingOverview.tsx
+++ b/frontend/src/maaling/overview/MaalingOverview.tsx
@@ -1,7 +1,10 @@
 import './maaling-overview.scss';
 
 import ErrorCard from '@common/error/ErrorCard';
-import React from 'react';
+import toError from '@common/error/util';
+import useInterval from '@common/hooks/useInterval';
+import { fetchMaaling } from '@maaling/api/maaling-api';
+import React, { useCallback } from 'react';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 
 import { MaalingContext } from '../types';
@@ -12,6 +15,7 @@ import MaalingStatusContainer from './status/MaalingStatusContainer';
 const MaalingOverview = () => {
   const {
     contextError,
+    setContextError,
     contextLoading,
     maaling,
     handleStartCrawling,
@@ -20,11 +24,39 @@ const MaalingOverview = () => {
     testStatus,
     clearTestStatus,
     refreshMaaling,
+    setMaaling,
+    pollMaaling,
+    setPollMaaling,
   }: MaalingContext = useOutletContext();
   const { id } = useParams();
   const navigate = useNavigate();
 
-  if (contextLoading) {
+  const doPollMaaling = useCallback(async () => {
+    setContextError(undefined);
+
+    if (id) {
+      try {
+        const refreshedMaaling = await fetchMaaling(Number(id));
+
+        if (!refreshedMaaling) {
+          setContextError(new Error('Fann ikkje måling'));
+        }
+
+        if (!['crawling', 'testing'].includes(refreshedMaaling.status)) {
+          setPollMaaling(false);
+        }
+        setMaaling(refreshedMaaling);
+      } catch (e) {
+        setContextError(toError(e, 'Noko gikk gale ved henting av måling'));
+      }
+    } else {
+      setContextError(new Error('Måling finnes ikkje'));
+    }
+  }, []);
+
+  useInterval(() => doPollMaaling(), pollMaaling ? 15000 : null);
+
+  if (contextLoading || (!maaling && id)) {
     return <MaalingSkeleton />;
   }
 

--- a/frontend/src/maaling/overview/maaling-overview.scss
+++ b/frontend/src/maaling/overview/maaling-overview.scss
@@ -53,6 +53,12 @@
         display: flex;
         justify-content: center;
       }
+
+      &-icon {
+        display: flex;
+        flex-direction: row;
+        gap: 1rem;
+      }
     }
 
     &__alert {

--- a/frontend/src/maaling/overview/status/MaalingStatusContainer.tsx
+++ b/frontend/src/maaling/overview/status/MaalingStatusContainer.tsx
@@ -2,7 +2,7 @@ import AlertTimed from '@common/alert/AlertTimed';
 import { appRoutes, getFullPath, idPath } from '@common/appRoutes';
 import TestlabLoadingButton from '@common/button/TestlabLoadingButton';
 import StatusBadge from '@common/status-badge/StatusBadge';
-import { List, ListItem } from '@digdir/design-system-react';
+import { List, ListItem, Spinner } from '@digdir/design-system-react';
 import React from 'react';
 
 import { Maaling } from '../../api/types';
@@ -31,20 +31,27 @@ const MaalingStatusContainer = ({
   const { crawlingStatus, testingStatus, publishStatus } =
     maalingOverviewStatus;
 
+  const pollingStatuses = ['crawling', 'testing'];
+
   return (
     <div className="status">
       <List>
         <ListItem>
           <div className="status__list-item">
             <div className="bold-text">Status</div>
-            <StatusBadge
-              status={maaling.status}
-              levels={{
-                primary: ['crawling', 'testing'],
-                success: ['testing_ferdig'],
-                danger: [],
-              }}
-            />
+            <div className="status__list-item-icon">
+              <StatusBadge
+                status={maaling.status}
+                levels={{
+                  primary: pollingStatuses,
+                  success: ['testing_ferdig'],
+                  danger: [],
+                }}
+              />
+              {pollingStatuses.includes(maaling.status) && (
+                <Spinner title="Oppdaterer måling" variant="inverted" />
+              )}
+            </div>
           </div>
         </ListItem>
         <ListItem>

--- a/frontend/src/maaling/types.ts
+++ b/frontend/src/maaling/types.ts
@@ -22,6 +22,8 @@ export interface MaalingContext extends AppContext {
   handleStartPublish: (maaling: Maaling) => void;
   testStatus: MaalingTestStatus;
   clearTestStatus: () => void;
+  pollMaaling: boolean;
+  setPollMaaling: (pollMaaling: boolean) => void;
 }
 
 export type CrawlUrl = {


### PR DESCRIPTION
- Flyttet måling polling til oversiktsbildet for måling
- Flyttet loading ut av withLoadingAndErrorHandling -> withErrorHandling
- Viser spinner i oversiktsbildet ved polling
- [BUGFIX] Feilmelding ved refresh av måling eller første gang man går inn på en måling