### PR TITLE
viser data fra lagrede resultater

### DIFF
--- a/frontend/src/inngaaende-test/test-overview/loeysing-test/TestOverviewLoeysing.tsx
+++ b/frontend/src/inngaaende-test/test-overview/loeysing-test/TestOverviewLoeysing.tsx
@@ -52,9 +52,7 @@ const TestOverviewLoeysing = () => {
   const [testResultsLoeysing, setTestResultsLoeysing] = useState<
     ResultatManuellKontroll[]
   >(getTestResultsForLoeysing(contextTestResults, Number(loeysingId)));
-  // const [allNonRelevant, setAllNonRelevant] = useState(
-  //   isAllNonRelevant(testResultsLoeysing)
-  // );
+
   const [nettsideProperties, setNettsideProperties] = useState(
     getNettsideProperties(contextSak, Number(loeysingId))
   );
@@ -104,7 +102,7 @@ const TestOverviewLoeysing = () => {
     setSak(contextSak);
     setTestregelList(testregelList);
     setTestResultsLoeysing(filteredTestResults);
-    // setAllNonRelevant(isAllNonRelevant(filteredTestResults));
+
     setNettsideProperties(filteredNettsideProperties);
     setProgressionPercent(
       progressionForLoeysingNettside(
@@ -159,24 +157,6 @@ const TestOverviewLoeysing = () => {
       setActiveTestregel(undefined);
     }
   }, []);
-
-  // const toggleAllNonRelevant = useCallback(() => {
-  //   // TODO - TA BORT, oppdater testresulat i api
-  //   const nextToggle = !allNonRelevant;
-  //   setAllNonRelevant(nextToggle);
-  //   if (nextToggle) {
-  //     setTestStatusMap((currentMap) => {
-  //       const updatedMap = new Map(currentMap);
-  //
-  //       updatedMap.forEach((value, key) => {
-  //         updatedMap.set(key, 'deaktivert');
-  //       });
-  //
-  //       return updatedMap;
-  //     });
-  //   }
-  //   // TODO - TA BORT
-  // }, [allNonRelevant]);
 
   const onChangeTestregel = useCallback(
     (testregelId: number) => {
@@ -256,9 +236,6 @@ const TestOverviewLoeysing = () => {
 
         updatedMap.set(statusKey, status);
         setTestStatusMap(updatedMap);
-        // setAllNonRelevant((prevAllRelevant) =>
-        //   prevAllRelevant ? false : prevAllRelevant
-        // );
       }
     },
     [sak, testStatusMap, loeysingId, testResultsLoeysing, pageType.nettsideId]
@@ -371,8 +348,6 @@ const TestOverviewLoeysing = () => {
         <TestRegelParamSelection
           pageType={pageType.pageType}
           contentType={contentType}
-          // allNonRelevant={allNonRelevant}
-          // toggleAllNonRelevant={toggleAllNonRelevant}
           progressionPercent={progressionPercent}
         />
         <div className="testregel-container">
@@ -400,6 +375,13 @@ const TestOverviewLoeysing = () => {
           <div className="testregel-form-wrapper">
             <TestForm
               testregel={activeTestregel}
+              resultat={findActiveTestResult(
+                testResultsLoeysing,
+                Number(sakId),
+                Number(loeysingId),
+                activeTestregel.id,
+                pageType.nettsideId
+              )}
               onClickBack={onClickBack}
               onClickSave={onClickSave}
               onResultat={doUpdateTestResult}


### PR DESCRIPTION
I forbindelse med ny parsing av testregler forsvant funksjonaliteten for å vise de lagrede resultatene. Fikset her. Neste steg er å kunne ha flere resultater for hver testregel, sånn at vi kan legge til flere elementer. 

DFK-452