### PR TITLE
accordion for testregelskjemaer

### DIFF
--- a/frontend/src/inngaaende-test/api/types.ts
+++ b/frontend/src/inngaaende-test/api/types.ts
@@ -1,3 +1,6 @@
+import { finnSvar, TestregelResultat } from '@test/util/testregelParser';
+import { Testregel } from '@testreglar/api/types';
+
 export type Svar = {
   steg: string;
   svar: string;
@@ -32,3 +35,28 @@ export type ResultatStatus =
   | 'Deaktivert'
   | 'UnderArbeid'
   | 'IkkjePaabegynt';
+
+export function toElementResultat(
+  resultat: TestregelResultat
+): ElementResultat {
+  if (resultat.type === 'avslutt') {
+    switch (resultat.fasit) {
+      case 'Ja':
+        return 'samsvar';
+      case 'Nei':
+        return 'brot';
+      case 'Ikkje testbart':
+        return 'ikkjeTesta';
+    }
+  } else {
+    return 'ikkjeForekomst';
+  }
+}
+
+export function findElementOmtale(
+  testregel: Testregel,
+  svar: Svar[]
+): string | undefined {
+  const element = JSON.parse(testregel.testregelSchema).element;
+  return finnSvar(element, svar);
+}

--- a/frontend/src/inngaaende-test/test-overview/loeysing-test/TestOverviewLoeysing.tsx
+++ b/frontend/src/inngaaende-test/test-overview/loeysing-test/TestOverviewLoeysing.tsx
@@ -1,7 +1,7 @@
 import AlertTimed from '@common/alert/AlertTimed';
 import useAlert from '@common/alert/useAlert';
-import { getFullPath, idPath, IdReplacement } from '@common/util/routeUtils';
 import { asList } from '@common/util/arrayUtils';
+import { getFullPath, idPath, IdReplacement } from '@common/util/routeUtils';
 import { isDefined, isNotDefined } from '@common/util/validationUtils';
 import { Sak } from '@sak/api/types';
 import { createTestResultat, updateTestResultat } from '@test/api/testing-api';
@@ -10,6 +10,7 @@ import {
   ResultatManuellKontroll,
   ResultatStatus,
   Svar,
+  toElementResultat,
 } from '@test/api/types';
 import TestregelButton from '@test/test-overview/loeysing-test/button/TestregelButton';
 import TestFerdig from '@test/test-overview/loeysing-test/TestFerdig';
@@ -22,10 +23,7 @@ import {
   PageType,
   TestContext,
 } from '@test/types';
-import {
-  TestregelResultat,
-  toElementResultat,
-} from '@test/util/testregelParser';
+import { TestregelResultat } from '@test/util/testregelParser';
 import {
   findActiveTestResult,
   getInitialPageType,

--- a/frontend/src/inngaaende-test/test-overview/loeysing-test/TestRegelParamSelection.tsx
+++ b/frontend/src/inngaaende-test/test-overview/loeysing-test/TestRegelParamSelection.tsx
@@ -31,7 +31,7 @@ const TestRegelParamSelection = ({
       {/*</Switch>*/}
       <LoadingBar
         ariaLabel={`${progressionPercent}% ferdig`}
-        customText="Progressjon"
+        customText="Progresjon"
         dynamicSeverity={false}
         labelPlacement="right"
         percentage={progressionPercent}

--- a/frontend/src/inngaaende-test/test.scss
+++ b/frontend/src/inngaaende-test/test.scss
@@ -23,6 +23,7 @@
       text-align: center;
       gap: 4rem;
       padding: 0 4rem 2rem 4rem;
+
       .content {
         display: flex;
         flex-direction: column;
@@ -116,6 +117,7 @@
 
   &-heading {
     padding-bottom: 3rem;
+
     .tags {
       display: flex;
       flex-direction: row;
@@ -130,6 +132,7 @@
 .test-form {
   display: flex;
   flex-direction: column;
+  gap: 2rem;
   justify-content: center;
   max-width: 48rem;
   width: 100%;
@@ -139,10 +142,6 @@
   div[class*='fds-textarea-description-'],
   div[class*='fds-fieldset-description-'] {
     font-size: 14px !important;
-  }
-
-  h3 {
-    margin-bottom: 2rem;
   }
 
   &-content {
@@ -155,6 +154,7 @@
     display: flex;
     flex-direction: row;
     gap: 1rem;
+
     &__help {
       display: block;
     }
@@ -165,6 +165,7 @@
     flex-direction: column;
     gap: 3rem;
     padding-bottom: 2rem;
+
     &-result {
       display: flex;
       align-items: start;

--- a/frontend/src/inngaaende-test/testregel-form/TestFormAccordion.tsx
+++ b/frontend/src/inngaaende-test/testregel-form/TestFormAccordion.tsx
@@ -1,0 +1,66 @@
+import { Accordion } from '@digdir/design-system-react';
+import { findElementOmtale, Svar } from '@test/api/types';
+import TestFormResultat from '@test/testregel-form/TestFormResultat';
+import TestFormStepWrapper from '@test/testregel-form/TestFormStepWrapper';
+import { SkjemaMedSvar } from '@test/testregel-form/types';
+import { Testregel } from '@testreglar/api/types';
+
+type Props = {
+  testregel: Testregel;
+  skjemaerMedSvar: SkjemaMedSvar[];
+  onAnswer: (svar: Svar, index: number) => void;
+};
+
+export function TestFormAccordion({
+  testregel,
+  skjemaerMedSvar,
+  onAnswer,
+}: Props) {
+  function renderForm(resultatId: number, skjemaMedSvar: SkjemaMedSvar) {
+    return (
+      <div key={resultatId} className="test-form-content">
+        {skjemaMedSvar.skjema.steg.map((etSteg) => (
+          <div key={etSteg.stegnr}>
+            <TestFormStepWrapper
+              steg={etSteg}
+              alleSvar={skjemaMedSvar.svar}
+              onAnswer={(svar) => onAnswer(svar, 0)}
+            />
+          </div>
+        ))}
+        {skjemaMedSvar.skjema.resultat && (
+          <TestFormResultat resultat={skjemaMedSvar.skjema.resultat} />
+        )}
+      </div>
+    );
+  }
+
+  if (skjemaerMedSvar.length === 1) {
+    const skjemaMedSvar = skjemaerMedSvar[0];
+    const resultatId = skjemaMedSvar.resultatId;
+    return renderForm(resultatId, skjemaMedSvar);
+  } else {
+    return (
+      <Accordion>
+        {skjemaerMedSvar.map((skjemaMedSvar, index) => {
+          const elementOmtale = findElementOmtale(
+            testregel,
+            skjemaMedSvar.svar
+          );
+          const resultatId = skjemaMedSvar.resultatId;
+          return (
+            <Accordion.Item key={skjemaMedSvar.resultatId} defaultOpen={true}>
+              <Accordion.Header>
+                {index + 1}
+                {elementOmtale && ': ' + elementOmtale}
+              </Accordion.Header>
+              <Accordion.Content>
+                {renderForm(resultatId, skjemaMedSvar)}
+              </Accordion.Content>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
+    );
+  }
+}

--- a/frontend/src/inngaaende-test/testregel-form/TestFormStepWrapper.tsx
+++ b/frontend/src/inngaaende-test/testregel-form/TestFormStepWrapper.tsx
@@ -27,7 +27,13 @@ const TestFormStepWrapper = ({ steg, alleSvar, onAnswer }: FormStepProps) => {
 
   switch (steg.type) {
     case 'tekst':
-      return <TestFormInputText steg={steg} onAnswer={onAnswer} />;
+      return (
+        <TestFormInputText
+          steg={steg}
+          svar={finnSvar(steg.stegnr, alleSvar)}
+          onAnswer={onAnswer}
+        />
+      );
     case 'instruksjon':
       return <TestFormDescription steg={steg} />;
     case 'radio':

--- a/frontend/src/inngaaende-test/testregel-form/types.ts
+++ b/frontend/src/inngaaende-test/testregel-form/types.ts
@@ -2,6 +2,7 @@ import { Svar } from '@test/api/types';
 import { TestregelSkjema } from '@test/util/testregelParser';
 
 export type SkjemaMedSvar = {
+  resultatId: number;
   skjema: TestregelSkjema;
   svar: Svar[];
 };

--- a/frontend/src/inngaaende-test/util/testregelParser.ts
+++ b/frontend/src/inngaaende-test/util/testregelParser.ts
@@ -1,5 +1,5 @@
 import { dropWhile, first } from '@common/util/arrayUtils';
-import { ElementResultat, Svar } from '@test/api/types';
+import { Svar } from '@test/api/types';
 import { Delutfall } from '@test/util/testregel-interface/Delutfall';
 import {
   Handling,
@@ -25,23 +25,6 @@ export type Avslutt = {
   fasit: Exclude<HandlingFasitTyper, 'sjekkDelutfall'>;
   utfall: string;
 };
-
-export function toElementResultat(
-  resultat: TestregelResultat
-): ElementResultat {
-  if (resultat.type === 'avslutt') {
-    switch (resultat.fasit) {
-      case 'Ja':
-        return 'samsvar';
-      case 'Nei':
-        return 'brot';
-      case 'Ikkje testbart':
-        return 'ikkjeTesta';
-    }
-  } else {
-    return 'ikkjeForekomst';
-  }
-}
 
 export function finnSvar(stegnr: string, alleSvar: Svar[]): string | undefined {
   return alleSvar.find((svar) => svar.steg === stegnr)?.svar;


### PR DESCRIPTION
Lager en accordion for testregelskjemaer, sånn at det er mulig å vise flere resultater under samme testregel. Når det bare er ett resultat, vises ikke accordion.

DFK-483