### PR TITLE
tillater endring av svar i tekstfelt

### DIFF
--- a/frontend/src/common/util/arrayUtils.ts
+++ b/frontend/src/common/util/arrayUtils.ts
@@ -30,6 +30,6 @@ export function dropWhile<T>(array: T[], predicate: (t: T) => boolean): T[] {
   return result;
 }
 
-export function asList<T>(value: T | undefined): T[] {
-  return value ? [value] : [];
+export function isEmpty<T>(array: T[]): boolean {
+  return array.length === 0;
 }

--- a/frontend/src/inngaaende-test/__tests__/testregel-form/TestForm.test.tsx
+++ b/frontend/src/inngaaende-test/__tests__/testregel-form/TestForm.test.tsx
@@ -1,6 +1,6 @@
 import { ResultatManuellKontroll } from '@test/api/types';
 import TestForm from '@test/testregel-form/TestForm';
-import { Testregel as TestregelSchema } from '@test/util/testregel-interface/Testregel';
+import { TestregelSchema } from '@test/util/testregel-interface/TestregelSchema';
 import { render, screen } from '@testing-library/react';
 import { Testregel } from '@testreglar/api/types';
 import * as fs from 'fs';

--- a/frontend/src/inngaaende-test/__tests__/util/testregelParser.test.ts
+++ b/frontend/src/inngaaende-test/__tests__/util/testregelParser.test.ts
@@ -1,5 +1,5 @@
 import { Svar } from '@test/api/types';
-import { Testregel } from '@test/util/testregel-interface/Testregel';
+import { TestregelSchema } from '@test/util/testregel-interface/TestregelSchema';
 import * as fs from 'fs';
 import * as path from 'path';
 import { describe, expect, test } from 'vitest';
@@ -7,7 +7,7 @@ import { describe, expect, test } from 'vitest';
 import { evaluateTestregel } from '../../util/testregelParser';
 
 describe('makeViewModel spec', () => {
-  function getTestregel(navn: string): Testregel {
+  function getTestregel(navn: string): TestregelSchema {
     const filePath = path.resolve(__dirname, `test-data/${navn}.json`);
     const buffer = fs.readFileSync(filePath);
     return JSON.parse(buffer.toString());
@@ -58,7 +58,7 @@ describe('makeViewModel spec', () => {
   });
 
   test('når det er ruting med radioboks, så skal vi få det resultatet som hører til den valgte radioboksen', () => {
-    const testregel: Testregel = getTestregel('1.4.5a');
+    const testregel: TestregelSchema = getTestregel('1.4.5a');
     const fellesSvar: Svar[] = [
       { steg: '2.2', svar: 'Ja' },
       { steg: '2.3', svar: 'Ja' },
@@ -109,7 +109,7 @@ describe('makeViewModel spec', () => {
   });
 
   test('når et svar er gitt, så skal vi gå videre til neste input', () => {
-    const testregel: Testregel = getTestregel('1.4.5a');
+    const testregel: TestregelSchema = getTestregel('1.4.5a');
     const model = evaluateTestregel(testregel, [
       { steg: '2.2', svar: 'Ja' },
       { steg: '2.3', svar: 'Ja' },

--- a/frontend/src/inngaaende-test/testregel-form/types.ts
+++ b/frontend/src/inngaaende-test/testregel-form/types.ts
@@ -1,10 +1,10 @@
 import { ResultatManuellKontroll, Svar } from '@test/api/types';
-import { evaluateTestregel, TestregelSkjema } from '@test/util/testregelParser';
+import { evaluateTestregel, TestregelForm } from '@test/util/testregelParser';
 import { Testregel } from '@testreglar/api/types';
 
 export type SkjemaMedSvar = {
   resultatId: number;
-  skjema: TestregelSkjema;
+  skjema: TestregelForm;
   svar: Svar[];
 };
 

--- a/frontend/src/inngaaende-test/util/testregel-interface/TestregelSchema.ts
+++ b/frontend/src/inngaaende-test/util/testregel-interface/TestregelSchema.ts
@@ -3,7 +3,7 @@ import { Steg } from './Steg';
 /**
  * Testregel
  */
-export interface Testregel {
+export interface TestregelSchema {
   /**  Namn på testreglen */
   namn: string;
   /** Id på testreglen */

--- a/frontend/src/inngaaende-test/util/testregelParser.ts
+++ b/frontend/src/inngaaende-test/util/testregelParser.ts
@@ -10,9 +10,9 @@ import {
 } from '@test/util/testregel-interface/Handling';
 import { Regel } from '@test/util/testregel-interface/Regel';
 import { Steg } from '@test/util/testregel-interface/Steg';
-import { Testregel } from '@test/util/testregel-interface/Testregel';
+import { TestregelSchema } from '@test/util/testregel-interface/TestregelSchema';
 
-export type TestregelSkjema = {
+export type TestregelForm = {
   steg: Steg[];
   delutfall: Record<number, Delutfall>;
   resultat?: TestregelResultat;
@@ -31,10 +31,10 @@ export function finnSvar(stegnr: string, alleSvar: Svar[]): string | undefined {
 }
 
 export function evaluateTestregel(
-  testregel: Testregel | string,
+  testregel: TestregelSchema | string,
   alleSvar: Svar[]
-): TestregelSkjema {
-  const parsedTestregel: Testregel =
+): TestregelForm {
+  const parsedTestregel: TestregelSchema =
     typeof testregel === 'string' ? JSON.parse(testregel) : testregel;
   const stepsWithoutFirst = parsedTestregel.steg.slice(1);
 
@@ -42,10 +42,10 @@ export function evaluateTestregel(
 }
 
 function loop(
-  testregelSkjema: TestregelSkjema,
+  testregelSkjema: TestregelForm,
   resterendeSteg: Steg[],
   alleSvar: Svar[]
-): TestregelSkjema {
+): TestregelForm {
   if (resterendeSteg.length === 0) {
     return testregelSkjema;
   }


### PR DESCRIPTION
Endrer måten vi oppdaterer svar. Hvis et nytt svar gjelder et tekstfelt, og ruting går til samme steg uansett hva vi svarer, så endrer vi det svaret, uten å kaste resten av svarene.

DFK-441