### PR TITLE
et forslag til hvordan vi kan skrive raskere og enklere tester med fakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
             <artifactId>testlab2-security-lib</artifactId>
             <version>0.0.2-SNAPSHOT</version>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>1.0.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/no/uutilsynet/testlab2frontendserver/kontroll/TestgrunnlagAPIClient.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2frontendserver/kontroll/TestgrunnlagAPIClient.kt
@@ -1,0 +1,51 @@
+package no.uutilsynet.testlab2frontendserver.kontroll
+
+import java.net.URI
+import no.uutilsynet.testlab2frontendserver.common.RestHelper.getList
+import no.uutilsynet.testlab2frontendserver.common.TestingApiProperties
+import no.uutilsynet.testlab2frontendserver.resultat.TestgrunnlagType
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+interface ITestgrunnlagAPIClient {
+  fun createTestgrunnlag(nyttTestgrunnlag: TestgrunnlagAPIClient.NyttTestgrunnlag): Result<URI>
+
+  fun getTestgrunnlag(kontrollId: Int): Result<List<KontrollResource.TestgrunnlagDTO>>
+}
+
+@Component
+class TestgrunnlagAPIClient(
+    val restTemplate: RestTemplate,
+    val testingApiProperties: TestingApiProperties
+) : ITestgrunnlagAPIClient {
+  private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+  override fun createTestgrunnlag(nyttTestgrunnlag: NyttTestgrunnlag): Result<URI> {
+    logger.info(
+        "Lagar nytt testgrunnlag med type ${nyttTestgrunnlag.type} for kontroll ${nyttTestgrunnlag.kontrollId}")
+    return runCatching {
+      restTemplate.postForLocation(
+          "${testingApiProperties.url}/testgrunnlag/kontroll", nyttTestgrunnlag)
+          ?: throw IllegalStateException(
+              "Vi fikk ikkje location for det nye testgrunnlaget fra serveren")
+    }
+  }
+
+  override fun getTestgrunnlag(kontrollId: Int): Result<List<KontrollResource.TestgrunnlagDTO>> {
+    logger.info("Hentar testgrunnlag for kontroll $kontrollId")
+    return runCatching {
+      restTemplate.getList<KontrollResource.TestgrunnlagDTO>(
+          "${testingApiProperties.url}/testgrunnlag/kontroll/list/$kontrollId")
+    }
+  }
+
+  data class NyttTestgrunnlag(
+      val kontrollId: Int,
+      val namn: String,
+      val type: TestgrunnlagType,
+      val sideutval: List<Sideutval>,
+      val testregelIdList: List<Int>
+  )
+}

--- a/src/test/kotlin/no/uutilsynet/testlab2frontendserver/kontroll/KontrollResourceTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2frontendserver/kontroll/KontrollResourceTest.kt
@@ -1,0 +1,66 @@
+package no.uutilsynet.testlab2frontendserver.kontroll
+
+import com.github.javafaker.Faker
+import java.net.URI
+import java.time.Instant
+import no.uutilsynet.testlab2frontendserver.common.TestingApiProperties
+import no.uutilsynet.testlab2frontendserver.resultat.TestgrunnlagType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.web.client.RestTemplate
+
+class KontrollResourceTest {
+  private val faker = Faker()
+
+  @Test
+  fun `test at FakeTestgrunnlagAPIClient returnerer riktig data`() {
+    // Mocker disse avhengighetene, siden det ikke finnes noen fakes for dem. De brukes ikke i
+    // testen.
+    val mockRestTemplate = Mockito.mock(RestTemplate::class.java)
+    val mockTestingApiProperties = Mockito.mock(TestingApiProperties::class.java)
+
+    val kontrollResource =
+        KontrollResource(FakeTestgrunnlagAPIClient(), mockRestTemplate, mockTestingApiProperties)
+    val kontrollId = faker.number().randomNumber().toInt()
+    val nyttTestgrunnlag =
+        TestgrunnlagAPIClient.NyttTestgrunnlag(
+            kontrollId = kontrollId,
+            namn = faker.lorem().sentence(),
+            type = TestgrunnlagType.OPPRINNELEG_TEST,
+            sideutval = emptyList(),
+            testregelIdList = emptyList(),
+        )
+    val location = kontrollResource.nyttTestgrunnlag(kontrollId, nyttTestgrunnlag).headers.location
+    val testgrunnlagId = location?.path?.substringAfterLast("/")?.toInt()
+    val testgrunnlag = kontrollResource.testgrunnlagForKontroll(kontrollId).first()
+    assertThat(testgrunnlag.id).isEqualTo(testgrunnlagId)
+  }
+}
+
+class FakeTestgrunnlagAPIClient : ITestgrunnlagAPIClient {
+  private val faker = Faker()
+  private val database = mutableMapOf<Int, KontrollResource.TestgrunnlagDTO>()
+
+  override fun createTestgrunnlag(
+      nyttTestgrunnlag: TestgrunnlagAPIClient.NyttTestgrunnlag
+  ): Result<URI> {
+    val id = faker.number().randomNumber().toInt()
+    val testgrunnlag =
+        KontrollResource.TestgrunnlagDTO(
+            id = id,
+            kontrollId = nyttTestgrunnlag.kontrollId,
+            namn = nyttTestgrunnlag.namn,
+            type = nyttTestgrunnlag.type,
+            sideutval = nyttTestgrunnlag.sideutval,
+            testreglar = emptyList(),
+            datoOppretta = Instant.now())
+    database[id] = testgrunnlag
+    return Result.success(URI.create("http://localhost:8080/testgrunnlag/$id"))
+  }
+
+  override fun getTestgrunnlag(kontrollId: Int): Result<List<KontrollResource.TestgrunnlagDTO>> {
+    val testgrunnlagList = database.values.filter { it.kontrollId == kontrollId }
+    return Result.success(testgrunnlagList)
+  }
+}


### PR DESCRIPTION
Jeg har trukket ut kall til /testgrunnlag i en egen klasse som heter TestgrunnlagAPIClient, og laget et interface for denne klassen som heter ITestgrunnlagAPIClient.

I testen har jeg implementert dette interfacet og brukt det for å teste API-kallene. På den måten blir testen mye raskere enn om vi skal kjøre opp systemet og det er enkelt å finne ut hva som skjer (i motsetning til mocks).
