### PR TITLE
feat: returnerer opprettet testresultat

### DIFF
--- a/frontend/src/inngaaende-test/api/testing-api.ts
+++ b/frontend/src/inngaaende-test/api/testing-api.ts
@@ -18,7 +18,7 @@ export const getTestResults = async (
 
 export const createTestResultat = async (
   testResultat: CreateTestResultat
-): Promise<ResultatManuellKontroll[]> => {
+): Promise<ResultatManuellKontroll> => {
   return await fetchWrapper(testingApiBaseUrl, {
     method: 'POST',
     headers: {

--- a/frontend/src/inngaaende-test/test-overview/loeysing-test/TestOverviewLoeysing.tsx
+++ b/frontend/src/inngaaende-test/test-overview/loeysing-test/TestOverviewLoeysing.tsx
@@ -6,6 +6,7 @@ import { createTestresultatAggregert } from '@resultat/resultat-api';
 import {
   createTestResultat,
   deleteTestResultat,
+  getTestResults,
   updateTestResultat,
   updateTestResultatMany,
 } from '@test/api/testing-api';
@@ -184,7 +185,8 @@ const TestOverviewLoeysing = () => {
       testregelId: activeTest.testregel.id,
       sideutvalId: pageType.sideId,
     };
-    const alleResultater = await createTestResultat(nyttTestresultat);
+    await createTestResultat(nyttTestresultat);
+    const alleResultater = await getTestResults(Number(testgrunnlagId));
     setTestResults(alleResultater);
     processData(
       contextKontroll,
@@ -404,11 +406,12 @@ const TestOverviewLoeysing = () => {
         };
 
         try {
-          const createdTestResults = await createTestResultat(testResult);
-          setTestResults(createdTestResults);
+          await createTestResultat(testResult);
+          const results = await getTestResults(testgrunnlagId);
+          setTestResults(results);
           processData(
             contextKontroll,
-            createdTestResults,
+            results,
             loeysingId,
             pageType,
             innhaldstype,

--- a/src/main/kotlin/no/uutilsynet/testlab2frontendserver/testing/TestResource.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2frontendserver/testing/TestResource.kt
@@ -6,16 +6,14 @@ import no.uutilsynet.testlab2frontendserver.common.TestingApiProperties
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.ByteArrayResource
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
+import org.springframework.http.*
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MimeTypeUtils
 import org.springframework.util.MultiValueMap
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 @RequestMapping("api/v1/testing")
@@ -54,16 +52,17 @@ class TestResource(
   @PostMapping
   fun createTestResultat(
       @RequestBody createTestResultat: CreateTestResultat
-  ): ResponseEntity<List<ResultatManuellKontroll>> =
+  ): ResultatManuellKontroll =
       runCatching {
             logger.debug(
                 "Lagrer nytt testresultat med loeysingId: ${createTestResultat.loeysingId}, testregelId: ${createTestResultat.testregelId}, sideutalId: ${createTestResultat.sideutvalId}")
-            testresultatAPIClient.createTestResultat(createTestResultat)
-            getResultatManuellKontroll(createTestResultat.testgrunnlagId)
+            val testResultat =
+                testresultatAPIClient.createTestResultat(createTestResultat).getOrThrow()
+            testResultat
           }
           .getOrElse {
             logger.error("Kunne ikkje opprette testresultat", it)
-            throw it
+            throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)
           }
 
   @PutMapping

--- a/src/main/kotlin/no/uutilsynet/testlab2frontendserver/testing/TestresultatAPIClient.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2frontendserver/testing/TestresultatAPIClient.kt
@@ -1,13 +1,13 @@
 package no.uutilsynet.testlab2frontendserver.testing
 
-import java.net.URI
 import no.uutilsynet.testlab2frontendserver.common.TestingApiProperties
 import no.uutilsynet.testlab2frontendserver.testing.TestResource.TestresultatForKontroll
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.getForObject
 
 interface ITestresultatAPIClient {
-  fun createTestResultat(createTestResultat: CreateTestResultat): Result<URI>
+  fun createTestResultat(createTestResultat: CreateTestResultat): Result<ResultatManuellKontroll>
 
   fun getResultatForTestgrunnlag(testgrunnlagId: Int): Result<List<ResultatManuellKontroll>>
 }
@@ -19,11 +19,14 @@ class TestresultatAPIClient(
 ) : ITestresultatAPIClient {
   private val testresultUrl = "${testingApiProperties.url}/testresultat"
 
-  override fun createTestResultat(createTestResultat: CreateTestResultat): Result<URI> =
-      runCatching {
+  override fun createTestResultat(
+      createTestResultat: CreateTestResultat
+  ): Result<ResultatManuellKontroll> = runCatching {
+    val location =
         restTemplate.postForLocation(testresultUrl, createTestResultat)
             ?: throw IllegalStateException("Vi fikk ikkje location fra $testresultUrl")
-      }
+    restTemplate.getForObject(location)
+  }
 
   override fun getResultatForTestgrunnlag(
       testgrunnlagId: Int

--- a/src/test/kotlin/no/uutilsynet/testlab2frontendserver/fakes/FakeTestresultatAPIClient.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2frontendserver/fakes/FakeTestresultatAPIClient.kt
@@ -1,6 +1,5 @@
 package no.uutilsynet.testlab2frontendserver.fakes
 
-import java.net.URI
 import java.time.Instant
 import no.uutilsynet.testlab2frontendserver.testing.CreateTestResultat
 import no.uutilsynet.testlab2frontendserver.testing.ITestresultatAPIClient
@@ -9,7 +8,9 @@ import no.uutilsynet.testlab2frontendserver.testing.ResultatManuellKontroll
 object FakeTestresultatAPIClient : ITestresultatAPIClient {
   private val database = mutableMapOf<Int, ResultatManuellKontroll>()
 
-  override fun createTestResultat(createTestResultat: CreateTestResultat): Result<URI> {
+  override fun createTestResultat(
+      createTestResultat: CreateTestResultat
+  ): Result<ResultatManuellKontroll> {
     val id = fakeId()
     val testResultat =
         ResultatManuellKontroll(
@@ -28,7 +29,7 @@ object FakeTestresultatAPIClient : ITestresultatAPIClient {
             null,
             sistLagra = Instant.now())
     database[id] = testResultat
-    return Result.success(URI.create("http://localhost:8080/testresultat/$id"))
+    return Result.success(testResultat)
   }
 
   override fun getResultatForTestgrunnlag(

--- a/src/test/kotlin/no/uutilsynet/testlab2frontendserver/kontroll/KontrollResourceTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2frontendserver/kontroll/KontrollResourceTest.kt
@@ -94,8 +94,7 @@ class KontrollResourceTest {
             elementUtfall = null,
             testVartUtfoert = null,
             kommentar = null)
-    val response = testResource.createTestResultat(createTestResultat)
-    assertThat(response.statusCode.is2xxSuccessful).isTrue()
+    testResource.createTestResultat(createTestResultat)
 
     val deleteResponse = kontrollResource.slettTestgrunnlag(kontrollId, testgrunnlagId)
     assertThat(deleteResponse.statusCode).isEqualTo(HttpStatus.FORBIDDEN)


### PR DESCRIPTION
Skriver om endepunktet POST /api/v1/testing, til at den returnerer det nye objektet, i stedet for en liste av alle testresultater. Vi trenger dette objektet når vi skal kopiere testresultater i forbindelse med retest.

DFK-584
